### PR TITLE
Use keyword extraction for resume upload

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, UploadFile, File
 
 from core import tracker
 from main import providers
-from core.llm_utils import generate_cover_letter
+from core.llm_utils import generate_cover_letter, extract_keywords
 
 app = FastAPI()
 
@@ -45,6 +45,6 @@ async def history():
 @app.post("/upload-resume")
 async def upload_resume(file: UploadFile = File(...)):
     content = (await file.read()).decode()
-    # For now, just return keywords
-    keywords = generate_cover_letter(content, content)
+    # Extract keywords from the uploaded resume
+    keywords = extract_keywords(content)
     return {"keywords": keywords}


### PR DESCRIPTION
## Summary
- import `extract_keywords` in API server
- call `extract_keywords` from `/upload-resume`
- return keywords in JSON response
- ensure tests pass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f5879e6d0832b8420f3ad910975b3

## Summary by Sourcery

Use extract_keywords to extract and return keywords for resumes uploaded via the /upload-resume endpoint

New Features:
- Implement keyword extraction for uploaded resumes, returning extracted keywords in the API response

Enhancements:
- Import extract_keywords and replace placeholder cover letter generation in the /upload-resume endpoint