### PR TITLE
Update QAEngine to use LLM answer_question

### DIFF
--- a/core/llm_utils.py
+++ b/core/llm_utils.py
@@ -49,3 +49,15 @@ def generate_cover_letter(job_desc: str, resume: str) -> str:
         return response.choices[0].message.content.strip()
     except Exception:
         return ""
+
+
+def answer_question(question: str) -> str:
+    """Ask the LLM a question and return the answer."""
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": question}],
+        )
+        return response.choices[0].message.content.strip()
+    except Exception:
+        return ""

--- a/core/qa_engine.py
+++ b/core/qa_engine.py
@@ -31,7 +31,7 @@ class QAEngine:
         result = self.lookup(question)
         if result:
             return result
-        generated = llm_utils.generate_cover_letter(question, "")
+        generated = llm_utils.answer_question(question)
         confidence = 0.6
         if generated:
             confidence = 0.8


### PR DESCRIPTION
## Summary
- add a new helper `answer_question` in `llm_utils`
- use this helper in `QAEngine.answer`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f587ce180832ba0ff9e65f580c13a

## Summary by Sourcery

Introduce a dedicated answer_question utility to query the LLM and refactor QAEngine to leverage it for answering questions.

New Features:
- Introduce answer_question helper in llm_utils for direct LLM question answering

Enhancements:
- Update QAEngine.answer to use answer_question instead of generate_cover_letter